### PR TITLE
Implement Statusword retrieval

### DIFF
--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -3,6 +3,8 @@
 
 #include <array>
 #include <memory>
+#include <vector>
+#include "rclcpp/rclcpp.hpp"
 #include "can/can_interface.hpp"
 
 namespace motion_control_mecanum {
@@ -13,8 +15,16 @@ class MotorController {
 
   bool writeSpeeds(const std::array<double, 4> & speeds);
 
+  bool readStatusword(uint8_t node_id, uint16_t * out_status);
+
  private:
+  bool SdoTransaction(uint8_t node_id,
+    const std::vector<uint8_t> & request,
+    uint8_t expected_cmd,
+    std::vector<uint8_t> & response);
+
   std::shared_ptr<can_control::CanInterface> can_;
+  rclcpp::Logger logger_;
 };
 
 }  // namespace motion_control_mecanum

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -1,9 +1,11 @@
 #include "motion-control-mecanum/motor_controller.hpp"
+#include "motion-control-mecanum/motor_constants.hpp"
 
 namespace motion_control_mecanum {
 
 MotorController::MotorController(std::shared_ptr<can_control::CanInterface> can)
-: can_(std::move(can))
+: can_(std::move(can)),
+  logger_(rclcpp::get_logger("MotorController"))
 {
 }
 
@@ -23,6 +25,80 @@ bool MotorController::writeSpeeds(const std::array<double, 4> & speeds)
       return false;
     }
   }
+  return true;
+}
+
+bool MotorController::SdoTransaction(
+  uint8_t node_id,
+  const std::vector<uint8_t> & request,
+  uint8_t expected_cmd,
+  std::vector<uint8_t> & response)
+{
+  can_control::CanFrame request_frame;
+  request_frame.arbitration_id =
+    motor_controller::kSdoRequestBaseId + static_cast<uint32_t>(node_id);
+  request_frame.dlc = motor_controller::kSdoDlc;
+  request_frame.data = request;
+
+  if (!can_->Send(request_frame)) {
+    RCLCPP_ERROR(logger_, "Failed to send SDO command.");
+    return false;
+  }
+
+  can_control::CanFrame response_frame;
+  if (!can_->Receive(&response_frame, motor_controller::kReceiveTimeoutMs)) {
+    RCLCPP_ERROR(logger_, "Failed to receive SDO response.");
+    return false;
+  }
+  if (response_frame.arbitration_id !=
+    (motor_controller::kSdoResponseBaseId + static_cast<uint32_t>(node_id)))
+  {
+    RCLCPP_ERROR(logger_,
+      "Unexpected SDO response CAN ID: 0x%X", response_frame.arbitration_id);
+    return false;
+  }
+  if (response_frame.data.size() < motor_controller::kSdoDlc) {
+    RCLCPP_ERROR(logger_, "SDO response data length is insufficient.");
+    return false;
+  }
+  if (response_frame.data[0] != expected_cmd) {
+    RCLCPP_ERROR(logger_, "SDO response error: 0x%X", response_frame.data[0]);
+    return false;
+  }
+  response = response_frame.data;
+  return true;
+}
+
+bool MotorController::readStatusword(uint8_t node_id, uint16_t * out_status)
+{
+  static const uint8_t kSdoUploadRequestCmd = 0x40;
+  static const uint16_t kStatuswordObject = 0x6041;
+  static const uint8_t kStatuswordSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    kSdoUploadRequestCmd,
+    static_cast<uint8_t>(kStatuswordObject & 0xFF),
+    static_cast<uint8_t>((kStatuswordObject >> 8) & 0xFF),
+    kStatuswordSubindex,
+    0x00, 0x00, 0x00, 0x00};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(node_id, request_data,
+    motor_controller::kSdoExpectedResponseUpload, response_data))
+  {
+    return false;
+  }
+
+  if (response_data.size() < 8) {
+    return false;
+  }
+
+  uint32_t raw = response_data[4] |
+    (response_data[5] << 8) |
+    (response_data[6] << 16) |
+    (response_data[7] << 24);
+  *out_status = static_cast<uint16_t>(raw & 0xFFFF);
+  //RCLCPP_INFO(logger_, "Retrieved Statusword: 0x%04X", *out_status);
   return true;
 }
 


### PR DESCRIPTION
## Summary
- extend `MotorController` with a method to read the Statusword via SDO
- implement generic SDO transaction helper
- keep a logger inside `MotorController`
- refine SDO transaction handling to validate the response and print errors

## Testing
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bea99485c83228682d5864e604db8