### PR TITLE
Add DS402 operation mode and velocity SDO helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Motion Control Mecanum Package
 
 This package provides a simple example of a mecanum wheel motion controller for ROS 2.
+
+### New Features
+
+* Support for setting the DS402 *Modes of Operation* object (`0x6060`).
+* Ability to command target velocity using Profile Velocity Mode (`0x60FF`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -9,6 +9,14 @@
 
 namespace motion_control_mecanum {
 
+enum class OperationMode : int8_t {
+  kNoOperation = 0x00,
+  kProfilePosition = 0x01,
+  kProfileVelocity = 0x03,
+  kProfileTorque = 0x04,
+  kHoming = 0x06
+};
+
 class MotorController {
  public:
   explicit MotorController(std::shared_ptr<can_control::CanInterface> can);
@@ -23,6 +31,12 @@ class MotorController {
   bool EnableOperation(uint8_t node_id);
   bool DisableVoltage(uint8_t node_id);
   bool DisableOperation(uint8_t node_id);
+
+  // Set the DS402 Modes of Operation (object 0x6060).
+  bool SetModeOfOperation(uint8_t node_id, OperationMode mode);
+
+  // Set target velocity in Profile Velocity Mode (object 0x60FF).
+  bool SetTargetVelocity(uint8_t node_id, int32_t velocity);
 
  private:
   bool SendControlWord(uint8_t node_id, uint16_t control_value);

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -127,6 +127,55 @@ bool MotorController::DisableOperation(uint8_t node_id)
   return SendControlWord(node_id, motor_controller::kDisableOperationValue);
 }
 
+bool MotorController::SetModeOfOperation(uint8_t node_id, OperationMode mode)
+{
+  const uint16_t kModeObject = 0x6060;
+  const uint8_t kModeSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload1byteCmd,
+    static_cast<uint8_t>(kModeObject & 0xFF),
+    static_cast<uint8_t>((kModeObject >> 8) & 0xFF),
+    kModeSubindex,
+    static_cast<uint8_t>(mode),
+    0x00, 0x00, 0x00};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(node_id, request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetModeOfOperation(%u): failed", static_cast<unsigned>(node_id));
+    return false;
+  }
+  RCLCPP_INFO(logger_, "SetModeOfOperation(%u): mode %d", static_cast<unsigned>(node_id), static_cast<int>(mode));
+  return true;
+}
+
+bool MotorController::SetTargetVelocity(uint8_t node_id, int32_t velocity)
+{
+  const uint16_t kTargetVelocityObject = 0x60FF;
+  const uint8_t kTargetVelocitySubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload4byteCmd,
+    static_cast<uint8_t>(kTargetVelocityObject & 0xFF),
+    static_cast<uint8_t>((kTargetVelocityObject >> 8) & 0xFF),
+    kTargetVelocitySubindex,
+    static_cast<uint8_t>(velocity & 0xFF),
+    static_cast<uint8_t>((velocity >> 8) & 0xFF),
+    static_cast<uint8_t>((velocity >> 16) & 0xFF),
+    static_cast<uint8_t>((velocity >> 24) & 0xFF)};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(node_id, request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetTargetVelocity(%u): failed", static_cast<unsigned>(node_id));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::readStatusword(uint8_t node_id, uint16_t * out_status)
 {
   static const uint8_t kSdoUploadRequestCmd = 0x40;


### PR DESCRIPTION
## Summary
- add `OperationMode` enum and helper functions in `MotorController`
- allow setting mode of operation (`0x6060`) and target velocity (`0x60FF`)
- document new features in README

## Testing
- `ctest --output-on-failure` *(fails: "No tests were found" since dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_b_683bf0c1d9888322be57cc8d85df7679