### PR TITLE
Store CANopen node ID in MotorController

### DIFF
--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <memory>
 #include <vector>
+#include <cstdint>
 #include "rclcpp/rclcpp.hpp"
 #include "can/can_interface.hpp"
 
@@ -19,33 +20,33 @@ enum class OperationMode : int8_t {
 
 class MotorController {
  public:
-  explicit MotorController(std::shared_ptr<can_control::CanInterface> can);
+  MotorController(std::shared_ptr<can_control::CanInterface> can, uint8_t node_id);
 
   bool writeSpeeds(const std::array<double, 4> & speeds);
 
-  bool readStatusword(uint8_t node_id, uint16_t * out_status);
+  bool readStatusword(uint16_t * out_status);
 
-  bool FaultReset(uint8_t node_id);
-  bool Shutdown(uint8_t node_id);
-  bool SwitchOn(uint8_t node_id);
-  bool EnableOperation(uint8_t node_id);
-  bool DisableVoltage(uint8_t node_id);
-  bool DisableOperation(uint8_t node_id);
+  bool FaultReset();
+  bool Shutdown();
+  bool SwitchOn();
+  bool EnableOperation();
+  bool DisableVoltage();
+  bool DisableOperation();
 
   // Set the DS402 Modes of Operation (object 0x6060).
-  bool SetModeOfOperation(uint8_t node_id, OperationMode mode);
+  bool SetModeOfOperation(OperationMode mode);
 
   // Set target velocity in Profile Velocity Mode (object 0x60FF).
-  bool SetTargetVelocity(uint8_t node_id, int32_t velocity);
+  bool SetTargetVelocity(int32_t velocity);
 
  private:
-  bool SendControlWord(uint8_t node_id, uint16_t control_value);
-  bool SdoTransaction(uint8_t node_id,
-    const std::vector<uint8_t> & request,
+  bool SendControlWord(uint16_t control_value);
+  bool SdoTransaction(const std::vector<uint8_t> & request,
     uint8_t expected_cmd,
     std::vector<uint8_t> & response);
 
   std::shared_ptr<can_control::CanInterface> can_;
+  uint8_t node_id_;
   rclcpp::Logger logger_;
 };
 

--- a/src/motion-control-mecanum/motion_controller_node.cpp
+++ b/src/motion-control-mecanum/motion_controller_node.cpp
@@ -13,7 +13,8 @@ MotionControllerNode::MotionControllerNode(const rclcpp::NodeOptions & options)
 
   motion_controller_ = std::make_shared<MotionController>(radius, sep_x, sep_y);
   auto can_if = std::make_shared<can_control::SocketCanInterface>(can_dev);
-  motor_controller_ = std::make_shared<MotorController>(can_if);
+  int node_id_param = this->declare_parameter("node_id", 1);
+  motor_controller_ = std::make_shared<MotorController>(can_if, static_cast<uint8_t>(node_id_param));
 
   cmd_vel_sub_ = create_subscription<geometry_msgs::msg::Twist>(
     "cmd_vel", rclcpp::QoS(10),


### PR DESCRIPTION
## Summary
- keep node ID inside MotorController
- allow MotionControllerNode to set node ID parameter
- update controller methods to use stored node ID

## Testing
- `cmake .. && make` *(fails: could not find `ament_cmake`)*

------
https://chatgpt.com/codex/tasks/task_b_683bf27e329c83229e5a59ac7e644866