### PR TITLE
Add End Velocity setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This package provides a simple example of a mecanum wheel motion controller for 
 
 * Support for setting the DS402 *Modes of Operation* object (`0x6060`).
 * Ability to command target velocity using Profile Velocity Mode (`0x60FF`).
+* Ability to configure the end velocity parameter (`0x6082`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -39,6 +39,9 @@ class MotorController {
   // Set target velocity in Profile Velocity Mode (object 0x60FF).
   bool SetTargetVelocity(int32_t velocity);
 
+  // Set end velocity for deceleration stop (object 0x6082).
+  bool SetEndVelocity(int32_t velocity);
+
  private:
   bool SendControlWord(uint16_t control_value);
   bool SdoTransaction(const std::vector<uint8_t> & request,

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -176,6 +176,31 @@ bool MotorController::SetTargetVelocity(int32_t velocity)
   return true;
 }
 
+bool MotorController::SetEndVelocity(int32_t velocity)
+{
+  const uint16_t kEndVelocityObject = 0x6082;
+  const uint8_t kEndVelocitySubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload4byteCmd,
+    static_cast<uint8_t>(kEndVelocityObject & 0xFF),
+    static_cast<uint8_t>((kEndVelocityObject >> 8) & 0xFF),
+    kEndVelocitySubindex,
+    static_cast<uint8_t>(velocity & 0xFF),
+    static_cast<uint8_t>((velocity >> 8) & 0xFF),
+    static_cast<uint8_t>((velocity >> 16) & 0xFF),
+    static_cast<uint8_t>((velocity >> 24) & 0xFF)};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetEndVelocity(%u): failed", static_cast<unsigned>(node_id_));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::readStatusword(uint16_t * out_status)
 {
   static const uint8_t kSdoUploadRequestCmd = 0x40;


### PR DESCRIPTION
## Summary
- expose new SetEndVelocity API to configure object `0x6082`
- implement SDO write for End Velocity
- document new functionality in README

## Testing
- `cmake .. && make` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_683bf44dd3188322bf3379e812a82a79