### PR TITLE
Add Profile Deceleration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This package provides a simple example of a mecanum wheel motion controller for 
 
 * Support for setting the DS402 *Modes of Operation* object (`0x6060`).
 * Ability to command target velocity using Profile Velocity Mode (`0x60FF`).
+* Ability to configure Profile Deceleration (`0x6084`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -39,6 +39,9 @@ class MotorController {
   // Set target velocity in Profile Velocity Mode (object 0x60FF).
   bool SetTargetVelocity(int32_t velocity);
 
+  // Set profile deceleration used in Profile Velocity Mode (object 0x6084).
+  bool SetProfileDeceleration(int32_t deceleration);
+
  private:
   bool SendControlWord(uint16_t control_value);
   bool SdoTransaction(const std::vector<uint8_t> & request,

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -176,6 +176,31 @@ bool MotorController::SetTargetVelocity(int32_t velocity)
   return true;
 }
 
+bool MotorController::SetProfileDeceleration(int32_t deceleration)
+{
+  const uint16_t kProfileDecelObject = 0x6084;
+  const uint8_t kProfileDecelSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload4byteCmd,
+    static_cast<uint8_t>(kProfileDecelObject & 0xFF),
+    static_cast<uint8_t>((kProfileDecelObject >> 8) & 0xFF),
+    kProfileDecelSubindex,
+    static_cast<uint8_t>(deceleration & 0xFF),
+    static_cast<uint8_t>((deceleration >> 8) & 0xFF),
+    static_cast<uint8_t>((deceleration >> 16) & 0xFF),
+    static_cast<uint8_t>((deceleration >> 24) & 0xFF)};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetProfileDeceleration(%u): failed", static_cast<unsigned>(node_id_));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::readStatusword(uint16_t * out_status)
 {
   static const uint8_t kSdoUploadRequestCmd = 0x40;


### PR DESCRIPTION
## Summary
- add ability to configure Profile Deceleration (object 0x6084)
- expose new API on MotorController

## Testing
- `cmake` failed due to missing ROS packages

------
https://chatgpt.com/codex/tasks/task_b_683bf46234888322b6bffa59f1f24000