### PR TITLE
Add Quick stop deceleration SDO helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This package provides a simple example of a mecanum wheel motion controller for 
 
 * Support for setting the DS402 *Modes of Operation* object (`0x6060`).
 * Ability to command target velocity using Profile Velocity Mode (`0x60FF`).
+* Configure Quick stop deceleration via object `0x6085`.

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -39,6 +39,9 @@ class MotorController {
   // Set target velocity in Profile Velocity Mode (object 0x60FF).
   bool SetTargetVelocity(int32_t velocity);
 
+  // Set the Quick stop deceleration (object 0x6085).
+  bool SetQuickStopDeceleration(uint32_t decel);
+
  private:
   bool SendControlWord(uint16_t control_value);
   bool SdoTransaction(const std::vector<uint8_t> & request,

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -176,6 +176,31 @@ bool MotorController::SetTargetVelocity(int32_t velocity)
   return true;
 }
 
+bool MotorController::SetQuickStopDeceleration(uint32_t decel)
+{
+  const uint16_t kQuickStopObject = 0x6085;
+  const uint8_t kQuickStopSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload4byteCmd,
+    static_cast<uint8_t>(kQuickStopObject & 0xFF),
+    static_cast<uint8_t>((kQuickStopObject >> 8) & 0xFF),
+    kQuickStopSubindex,
+    static_cast<uint8_t>(decel & 0xFF),
+    static_cast<uint8_t>((decel >> 8) & 0xFF),
+    static_cast<uint8_t>((decel >> 16) & 0xFF),
+    static_cast<uint8_t>((decel >> 24) & 0xFF)};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetQuickStopDeceleration(%u): failed", static_cast<unsigned>(node_id_));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::readStatusword(uint16_t * out_status)
 {
   static const uint8_t kSdoUploadRequestCmd = 0x40;


### PR DESCRIPTION
## Summary
- control mecanum motor's quick stop deceleration via DS402 object `0x6085`
- document new feature in README

## Testing
- `colcon test --event-handlers console_cohesion+ --packages-select motion-control-mecanum` *(fails: colcon not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bf4808ce88322ac27889f9cce1cb2