### PR TITLE
Add Quick stop option code command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This package provides a simple example of a mecanum wheel motion controller for 
 
 * Support for setting the DS402 *Modes of Operation* object (`0x6060`).
 * Ability to command target velocity using Profile Velocity Mode (`0x60FF`).
+* Command to configure the **Quick stop option code** object (`0x605A`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -39,6 +39,9 @@ class MotorController {
   // Set target velocity in Profile Velocity Mode (object 0x60FF).
   bool SetTargetVelocity(int32_t velocity);
 
+  // Set the Quick stop option code (object 0x605A).
+  bool SetQuickStopOptionCode(int16_t option);
+
  private:
   bool SendControlWord(uint16_t control_value);
   bool SdoTransaction(const std::vector<uint8_t> & request,

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -176,6 +176,34 @@ bool MotorController::SetTargetVelocity(int32_t velocity)
   return true;
 }
 
+bool MotorController::SetQuickStopOptionCode(int16_t option)
+{
+  const uint16_t kQuickStopObject = 0x605A;
+  const uint8_t kQuickStopSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload2byteCmd,
+    static_cast<uint8_t>(kQuickStopObject & 0xFF),
+    static_cast<uint8_t>((kQuickStopObject >> 8) & 0xFF),
+    kQuickStopSubindex,
+    static_cast<uint8_t>(option & 0xFF),
+    static_cast<uint8_t>((option >> 8) & 0xFF),
+    0x00,
+    0x00};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetQuickStopOptionCode(%u): failed",
+      static_cast<unsigned>(node_id_));
+    return false;
+  }
+  RCLCPP_INFO(logger_, "SetQuickStopOptionCode(%u): option %d",
+    static_cast<unsigned>(node_id_), static_cast<int>(option));
+  return true;
+}
+
 bool MotorController::readStatusword(uint16_t * out_status)
 {
   static const uint8_t kSdoUploadRequestCmd = 0x40;


### PR DESCRIPTION
## Summary
- add ability to set Quick stop option code on CAN DS402
- document the new command in README

## Testing
- `cmake -S . -B build` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_683bf49a302c8322b402d8627969e9d3