### PR TITLE
Add Velocity window setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This package provides a simple example of a mecanum wheel motion controller for 
 
 * Support for setting the DS402 *Modes of Operation* object (`0x6060`).
 * Ability to command target velocity using Profile Velocity Mode (`0x60FF`).
+* Configure the Velocity window parameter (`0x606D`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -39,6 +39,9 @@ class MotorController {
   // Set target velocity in Profile Velocity Mode (object 0x60FF).
   bool SetTargetVelocity(int32_t velocity);
 
+  // Set Velocity window (object 0x606D).
+  bool SetVelocityWindow(uint16_t window);
+
  private:
   bool SendControlWord(uint16_t control_value);
   bool SdoTransaction(const std::vector<uint8_t> & request,

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -176,6 +176,30 @@ bool MotorController::SetTargetVelocity(int32_t velocity)
   return true;
 }
 
+bool MotorController::SetVelocityWindow(uint16_t window)
+{
+  const uint16_t kVelocityWindowObject = 0x606D;
+  const uint8_t kVelocityWindowSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload2byteCmd,
+    static_cast<uint8_t>(kVelocityWindowObject & 0xFF),
+    static_cast<uint8_t>((kVelocityWindowObject >> 8) & 0xFF),
+    kVelocityWindowSubindex,
+    static_cast<uint8_t>(window & 0xFF),
+    static_cast<uint8_t>((window >> 8) & 0xFF),
+    0x00, 0x00};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetVelocityWindow(%u): failed", static_cast<unsigned>(node_id_));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::readStatusword(uint16_t * out_status)
 {
   static const uint8_t kSdoUploadRequestCmd = 0x40;


### PR DESCRIPTION
## Summary
- add an API for setting the Velocity window (0x606D)
- document the new capability in README

## Testing
- `colcon test --packages-select motion-control-mecanum-pkg --event-handlers console_cohesion+ --return-code-on-test-failure` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683bf4adeb34832290c0dc69530fb704