### PR TITLE
Add Velocity Threshold setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This package provides a simple example of a mecanum wheel motion controller for 
 
 * Support for setting the DS402 *Modes of Operation* object (`0x6060`).
 * Ability to command target velocity using Profile Velocity Mode (`0x60FF`).
+* Ability to configure the velocity threshold (`0x606F`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -39,6 +39,9 @@ class MotorController {
   // Set target velocity in Profile Velocity Mode (object 0x60FF).
   bool SetTargetVelocity(int32_t velocity);
 
+  // Set velocity threshold (object 0x606F).
+  bool SetVelocityThreshold(uint16_t threshold);
+
  private:
   bool SendControlWord(uint16_t control_value);
   bool SdoTransaction(const std::vector<uint8_t> & request,

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -176,6 +176,32 @@ bool MotorController::SetTargetVelocity(int32_t velocity)
   return true;
 }
 
+bool MotorController::SetVelocityThreshold(uint16_t threshold)
+{
+  const uint16_t kVelocityThresholdObject = 0x606F;
+  const uint8_t kVelocityThresholdSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload2byteCmd,
+    static_cast<uint8_t>(kVelocityThresholdObject & 0xFF),
+    static_cast<uint8_t>((kVelocityThresholdObject >> 8) & 0xFF),
+    kVelocityThresholdSubindex,
+    static_cast<uint8_t>(threshold & 0xFF),
+    static_cast<uint8_t>((threshold >> 8) & 0xFF),
+    0x00,
+    0x00};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetVelocityThreshold(%u): failed",
+      static_cast<unsigned>(node_id_));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::readStatusword(uint16_t * out_status)
 {
   static const uint8_t kSdoUploadRequestCmd = 0x40;


### PR DESCRIPTION
## Summary
- allow configuration of motor velocity threshold via DS402 object 0x606F
- document the new velocity threshold feature

## Testing
- `cmake ..` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_683bf4caa83c8322970d012bbb3c6a08