### PR TITLE
Add Quick Stop option code setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ This package provides a simple example of a mecanum wheel motion controller for 
 * Ability to command target velocity using Profile Velocity Mode (`0x60FF`).
 * Ability to configure the velocity threshold (`0x606F`).
 * Ability to configure the velocity window (`0x606D`).
+* Ability to configure the quick stop option code (`0x605A`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -18,6 +18,17 @@ enum class OperationMode : int8_t {
   kHoming = 0x06
 };
 
+enum class QuickStopOptionCode : int16_t {
+  kCustomStopTime = -3,
+  kCustomStopRate = -2,
+  kImmediateStop = -1,
+  kImmediateDisableSwitch = 0,
+  kNormalRampDisableSwitch = 1,
+  kQuickStopRampDisableSwitch = 2,
+  kNormalRampStayQuickStop = 5,
+  kQuickStopRampStayQuickStop = 6
+};
+
 class MotorController {
  public:
   MotorController(std::shared_ptr<can_control::CanInterface> can, uint8_t node_id);
@@ -44,6 +55,9 @@ class MotorController {
 
   // Set velocity window (object 0x606D).
   bool SetVelocityWindow(uint16_t window);
+
+  // Set Quick stop option code (object 0x605A).
+  bool SetQuickStopOptionCode(QuickStopOptionCode option);
 
  private:
   bool SendControlWord(uint16_t control_value);

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -228,6 +228,33 @@ bool MotorController::SetVelocityWindow(uint16_t window)
   return true;
 }
 
+bool MotorController::SetQuickStopOptionCode(QuickStopOptionCode option)
+{
+  const uint16_t kQuickStopOptionObject = 0x605A;
+  const uint8_t kQuickStopOptionSubindex = 0x00;
+
+  int16_t value = static_cast<int16_t>(option);
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload2byteCmd,
+    static_cast<uint8_t>(kQuickStopOptionObject & 0xFF),
+    static_cast<uint8_t>((kQuickStopOptionObject >> 8) & 0xFF),
+    kQuickStopOptionSubindex,
+    static_cast<uint8_t>(value & 0xFF),
+    static_cast<uint8_t>((value >> 8) & 0xFF),
+    0x00,
+    0x00};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetQuickStopOptionCode(%u): failed",
+      static_cast<unsigned>(node_id_));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::readStatusword(uint16_t * out_status)
 {
   static const uint8_t kSdoUploadRequestCmd = 0x40;


### PR DESCRIPTION
## Summary
- add QuickStopOptionCode enum and SetQuickStopOptionCode API
- implement QuickStopOptionCode SDO write in motor controller
- document QuickStop option code configuration in README

## Testing
- `cmake ..` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_683bf82fe3e483228fe1fef60a721a7f