### PR TITLE
Add QuickStop deceleration configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ This package provides a simple example of a mecanum wheel motion controller for 
 * Ability to configure the velocity threshold (`0x606F`).
 * Ability to configure the velocity window (`0x606D`).
 * Ability to configure the quick stop option code (`0x605A`).
+* Ability to configure the quick stop deceleration (`0x6085`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -59,6 +59,9 @@ class MotorController {
   // Set Quick stop option code (object 0x605A).
   bool SetQuickStopOptionCode(QuickStopOptionCode option);
 
+  // Set Quick stop deceleration (object 0x6085).
+  bool SetQuickStopDeceleration(uint32_t deceleration);
+
  private:
   bool SendControlWord(uint16_t control_value);
   bool SdoTransaction(const std::vector<uint8_t> & request,

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -255,6 +255,32 @@ bool MotorController::SetQuickStopOptionCode(QuickStopOptionCode option)
   return true;
 }
 
+bool MotorController::SetQuickStopDeceleration(uint32_t deceleration)
+{
+  const uint16_t kQuickStopDecelObject = 0x6085;
+  const uint8_t kQuickStopDecelSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload4byteCmd,
+    static_cast<uint8_t>(kQuickStopDecelObject & 0xFF),
+    static_cast<uint8_t>((kQuickStopDecelObject >> 8) & 0xFF),
+    kQuickStopDecelSubindex,
+    static_cast<uint8_t>(deceleration & 0xFF),
+    static_cast<uint8_t>((deceleration >> 8) & 0xFF),
+    static_cast<uint8_t>((deceleration >> 16) & 0xFF),
+    static_cast<uint8_t>((deceleration >> 24) & 0xFF)};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetQuickStopDeceleration(%u): failed",
+      static_cast<unsigned>(node_id_));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::readStatusword(uint16_t * out_status)
 {
   static const uint8_t kSdoUploadRequestCmd = 0x40;


### PR DESCRIPTION
## Summary
- add method to configure Quick stop deceleration (0x6085)
- document new feature in README

## Testing
- `cmake .. && make` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_683bf918c37c8322b4789d4aae1ba5e9