### PR TITLE
Add profile acceleration setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ This package provides a simple example of a mecanum wheel motion controller for 
 * Ability to configure the quick stop option code (`0x605A`).
 * Ability to configure the quick stop deceleration (`0x6085`).
 * Ability to configure the maximum torque limit (`0x6072`).
+* Ability to configure the profile acceleration (`0x6083`).
 * Ability to configure the profile deceleration (`0x6084`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -62,6 +62,9 @@ class MotorController {
   // Set Quick stop deceleration (object 0x6085).
   bool SetQuickStopDeceleration(uint32_t deceleration);
 
+  // Set profile acceleration (object 0x6083).
+  bool SetProfileAcceleration(uint32_t acceleration);
+
   // Set profile deceleration (object 0x6084).
   bool SetProfileDeceleration(uint32_t deceleration);
 

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -281,6 +281,32 @@ bool MotorController::SetQuickStopDeceleration(uint32_t deceleration)
   return true;
 }
 
+bool MotorController::SetProfileAcceleration(uint32_t acceleration)
+{
+  const uint16_t kProfileAccelObject = 0x6083;
+  const uint8_t kProfileAccelSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload4byteCmd,
+    static_cast<uint8_t>(kProfileAccelObject & 0xFF),
+    static_cast<uint8_t>((kProfileAccelObject >> 8) & 0xFF),
+    kProfileAccelSubindex,
+    static_cast<uint8_t>(acceleration & 0xFF),
+    static_cast<uint8_t>((acceleration >> 8) & 0xFF),
+    static_cast<uint8_t>((acceleration >> 16) & 0xFF),
+    static_cast<uint8_t>((acceleration >> 24) & 0xFF)};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetProfileAcceleration(%u): failed",
+      static_cast<unsigned>(node_id_));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::SetProfileDeceleration(uint32_t deceleration)
 {
   const uint16_t kProfileDecelObject = 0x6084;


### PR DESCRIPTION
## Summary
- support configuring profile acceleration (0x6083) on the motor controller
- document profile acceleration capability in README

## Testing
- `cmake ..` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_683bfbbddb288322ac225a263fd9d6bc