### PR TITLE
Add profile velocity setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ This package provides a simple example of a mecanum wheel motion controller for 
 * Ability to configure the profile acceleration (`0x6083`).
 * Ability to configure the profile deceleration (`0x6084`).
 * Ability to configure the end velocity (`0x6082`).
+* Ability to configure the profile velocity (`0x6081`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -71,6 +71,9 @@ class MotorController {
   // Set end velocity (object 0x6082).
   bool SetEndVelocity(int32_t velocity);
 
+  // Set profile velocity (object 0x6081).
+  bool SetProfileVelocity(int32_t velocity);
+
   // Set maximum torque limit (object 0x6072).
   bool SetMaxTorque(uint16_t max_torque);
 

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -359,6 +359,32 @@ bool MotorController::SetEndVelocity(int32_t velocity)
   return true;
 }
 
+bool MotorController::SetProfileVelocity(int32_t velocity)
+{
+  const uint16_t kProfileVelocityObject = 0x6081;
+  const uint8_t kProfileVelocitySubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    motor_controller::kSdoDownload4byteCmd,
+    static_cast<uint8_t>(kProfileVelocityObject & 0xFF),
+    static_cast<uint8_t>((kProfileVelocityObject >> 8) & 0xFF),
+    kProfileVelocitySubindex,
+    static_cast<uint8_t>(velocity & 0xFF),
+    static_cast<uint8_t>((velocity >> 8) & 0xFF),
+    static_cast<uint8_t>((velocity >> 16) & 0xFF),
+    static_cast<uint8_t>((velocity >> 24) & 0xFF)};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+      motor_controller::kSdoExpectedResponseDownload, response_data))
+  {
+    RCLCPP_ERROR(logger_, "SetProfileVelocity(%u): failed",
+      static_cast<unsigned>(node_id_));
+    return false;
+  }
+  return true;
+}
+
 bool MotorController::SetMaxTorque(uint16_t max_torque)
 {
   const uint16_t kMaxTorqueObject = 0x6072;


### PR DESCRIPTION
## Summary
- add ability to configure the profile velocity via object 0x6081
- document the new capability

## Testing
- `g++ -std=c++17 -fsyntax-only -Iinclude src/motion-control-mecanum/motor_controller.cpp` *(fails: rclcpp headers not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bfe147fdc8322bb9a153d416aa200