### PR TITLE
Add methods to read torque and velocity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ This package provides a simple example of a mecanum wheel motion controller for 
 * Ability to configure the profile deceleration (`0x6084`).
 * Ability to configure the end velocity (`0x6082`).
 * Ability to configure the profile velocity (`0x6081`).
+* Ability to read the torque actual value (`0x6077`).
+* Ability to read the velocity actual value (`0x606C`).

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -37,6 +37,12 @@ class MotorController {
 
   bool readStatusword(uint16_t * out_status);
 
+  // Get the actual torque value (object 0x6077).
+  bool GetTorqueActualValue(int16_t * out_torque);
+
+  // Get the actual velocity value (object 0x606C).
+  bool GetVelocityActualValue(int32_t * out_velocity);
+
   bool FaultReset();
   bool Shutdown();
   bool SwitchOn();

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -444,4 +444,68 @@ bool MotorController::readStatusword(uint16_t * out_status)
   return true;
 }
 
+bool MotorController::GetTorqueActualValue(int16_t * out_torque)
+{
+  static const uint8_t kSdoUploadRequestCmd = 0x40;
+  static const uint16_t kTorqueActualObject = 0x6077;
+  static const uint8_t kTorqueActualSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    kSdoUploadRequestCmd,
+    static_cast<uint8_t>(kTorqueActualObject & 0xFF),
+    static_cast<uint8_t>((kTorqueActualObject >> 8) & 0xFF),
+    kTorqueActualSubindex,
+    0x00, 0x00, 0x00, 0x00};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+    motor_controller::kSdoExpectedResponseUpload, response_data))
+  {
+    return false;
+  }
+
+  if (response_data.size() < 8) {
+    return false;
+  }
+
+  uint32_t raw = response_data[4] |
+    (response_data[5] << 8) |
+    (response_data[6] << 16) |
+    (response_data[7] << 24);
+  *out_torque = static_cast<int16_t>(raw & 0xFFFF);
+  return true;
+}
+
+bool MotorController::GetVelocityActualValue(int32_t * out_velocity)
+{
+  static const uint8_t kSdoUploadRequestCmd = 0x40;
+  static const uint16_t kVelocityActualObject = 0x606C;
+  static const uint8_t kVelocityActualSubindex = 0x00;
+
+  std::vector<uint8_t> request_data = {
+    kSdoUploadRequestCmd,
+    static_cast<uint8_t>(kVelocityActualObject & 0xFF),
+    static_cast<uint8_t>((kVelocityActualObject >> 8) & 0xFF),
+    kVelocityActualSubindex,
+    0x00, 0x00, 0x00, 0x00};
+
+  std::vector<uint8_t> response_data;
+  if (!SdoTransaction(request_data,
+    motor_controller::kSdoExpectedResponseUpload, response_data))
+  {
+    return false;
+  }
+
+  if (response_data.size() < 8) {
+    return false;
+  }
+
+  uint32_t raw = response_data[4] |
+    (response_data[5] << 8) |
+    (response_data[6] << 16) |
+    (response_data[7] << 24);
+  *out_velocity = static_cast<int32_t>(raw);
+  return true;
+}
+
 }  // namespace motion_control_mecanum


### PR DESCRIPTION
## Summary
- expose new methods to read torque actual value and velocity actual value
- document these features in README

## Testing
- `colcon test --packages-select motion-control-mecanum-pkg` *(fails: `colcon` not found)*
- `cmake ..` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_6841b23379708322b6a96be3cb7c801e