### PR TITLE
Add motor parameter struct and wiring

### DIFF
--- a/include/motion-control-mecanum/motion_controller.hpp
+++ b/include/motion-control-mecanum/motion_controller.hpp
@@ -8,6 +8,7 @@
 #include "can/socket_can_interface.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "motion-control-mecanum/motor_controller.hpp"
+#include "motion-control-mecanum/motor_parameters.hpp"
 
 namespace motion_control_mecanum {
 
@@ -17,7 +18,8 @@ class MotionController {
                    double wheel_separation_y);
 
   MotionController(const std::string& can_device,
-                   const std::array<uint8_t, 4>& node_ids, double wheel_radius,
+                   const std::array<uint8_t, 4>& node_ids,
+                   const MotorParameters& motor_params, double wheel_radius,
                    double wheel_separation_x, double wheel_separation_y);
 
   std::array<double, 4> compute(const geometry_msgs::msg::Twist& cmd) const;

--- a/include/motion-control-mecanum/motion_controller_node.hpp
+++ b/include/motion-control-mecanum/motion_controller_node.hpp
@@ -5,6 +5,7 @@
 
 #include "geometry_msgs/msg/twist.hpp"
 #include "motion-control-mecanum/motion_controller.hpp"
+#include "motion-control-mecanum/motor_parameters.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/trigger.hpp"
 

--- a/include/motion-control-mecanum/motor_controller.hpp
+++ b/include/motion-control-mecanum/motor_controller.hpp
@@ -8,6 +8,7 @@
 
 #include "can/can_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "motion-control-mecanum/motor_parameters.hpp"
 
 namespace motion_control_mecanum {
 
@@ -34,6 +35,8 @@ class MotorController {
  public:
   MotorController(std::shared_ptr<can_control::CanInterface> can,
                   uint8_t node_id);
+  MotorController(std::shared_ptr<can_control::CanInterface> can,
+                  uint8_t node_id, const MotorParameters& params);
 
   bool writeSpeeds(const std::array<double, 4>& speeds);
 
@@ -92,6 +95,7 @@ class MotorController {
 
   std::shared_ptr<can_control::CanInterface> can_;
   uint8_t node_id_;
+  MotorParameters motor_params_{};
   rclcpp::Logger logger_;
 };
 

--- a/include/motion-control-mecanum/motor_parameters.hpp
+++ b/include/motion-control-mecanum/motor_parameters.hpp
@@ -1,0 +1,23 @@
+#ifndef MOTION_CONTROL_MECANUM__MOTOR_PARAMETERS_HPP_
+#define MOTION_CONTROL_MECANUM__MOTOR_PARAMETERS_HPP_
+
+#include <cstdint>
+
+namespace motion_control_mecanum {
+
+struct MotorParameters {
+  int32_t max_speed{0};
+  int32_t acceleration{0};
+  int32_t deceleration{0};
+  double gear_ratio{0.0};
+  int32_t encoder_resolution{0};
+  int32_t max_torque{0};
+  int32_t end_velocity{0};
+  int32_t quick_stop_deceleration{0};
+  int32_t velocity_window{0};
+  int32_t velocity_threshold{0};
+};
+
+}  // namespace motion_control_mecanum
+
+#endif  // MOTION_CONTROL_MECANUM__MOTOR_PARAMETERS_HPP_

--- a/src/motion-control-mecanum/motion_controller.cpp
+++ b/src/motion-control-mecanum/motion_controller.cpp
@@ -13,6 +13,7 @@ MotionController::MotionController(double wheel_radius,
 
 MotionController::MotionController(const std::string& can_device,
                                    const std::array<uint8_t, 4>& node_ids,
+                                   const MotorParameters& motor_params,
                                    double wheel_radius,
                                    double wheel_separation_x,
                                    double wheel_separation_y)
@@ -22,8 +23,8 @@ MotionController::MotionController(const std::string& can_device,
   can_interface_ =
       std::make_shared<can_control::SocketCanInterface>(can_device);
   for (size_t i = 0; i < motor_controllers_.size(); ++i) {
-    motor_controllers_[i] =
-        std::make_shared<MotorController>(can_interface_, node_ids[i]);
+    motor_controllers_[i] = std::make_shared<MotorController>(
+        can_interface_, node_ids[i], motor_params);
   }
 }
 

--- a/src/motion-control-mecanum/motion_controller_node.cpp
+++ b/src/motion-control-mecanum/motion_controller_node.cpp
@@ -1,6 +1,7 @@
 #include "motion-control-mecanum/motion_controller_node.hpp"
 
 #include "std_srvs/srv/trigger.hpp"
+#include "motion-control-mecanum/motor_parameters.hpp"
 
 namespace motion_control_mecanum {
 
@@ -17,9 +18,32 @@ MotionControllerNode::MotionControllerNode(const rclcpp::NodeOptions& options)
   std::string can_dev =
       this->declare_parameter<std::string>("can_device", "can0");
 
+  MotorParameters motor_params;
+  motor_params.max_speed =
+      this->declare_parameter<int>("motor_parameters.max_speed", 3000);
+  motor_params.acceleration =
+      this->declare_parameter<int>("motor_parameters.acceleration", 1000);
+  motor_params.deceleration =
+      this->declare_parameter<int>("motor_parameters.deceleration", 1000);
+  motor_params.gear_ratio =
+      this->declare_parameter<double>("motor_parameters.gear_ratio", 10.0);
+  motor_params.encoder_resolution =
+      this->declare_parameter<int>("motor_parameters.encoder_resolution", 4096);
+  motor_params.max_torque =
+      this->declare_parameter<int>("motor_parameters.max_torque", 1000);
+  motor_params.end_velocity =
+      this->declare_parameter<int>("motor_parameters.end_velocity", 0);
+  motor_params.quick_stop_deceleration =
+      this->declare_parameter<int>("motor_parameters.quick_stop_deceleration",
+                                   1000);
+  motor_params.velocity_window =
+      this->declare_parameter<int>("motor_parameters.velocity_window", 0);
+  motor_params.velocity_threshold =
+      this->declare_parameter<int>("motor_parameters.velocity_threshold", 0);
+
   std::array<uint8_t, 4> node_ids{1, 2, 3, 4};
-  motion_controller_ = std::make_shared<MotionController>(can_dev, node_ids,
-                                                          radius, sep_x, sep_y);
+  motion_controller_ = std::make_shared<MotionController>(
+      can_dev, node_ids, motor_params, radius, sep_x, sep_y);
 
   cmd_vel_sub_ = create_subscription<geometry_msgs::msg::Twist>(
       "cmd_vel", rclcpp::QoS(10),

--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -8,6 +8,21 @@ MotorController::MotorController(std::shared_ptr<can_control::CanInterface> can,
                                  uint8_t node_id)
     : can_(std::move(can)),
       node_id_(node_id),
+      motor_params_{},
+      logger_(rclcpp::get_logger("MotorController")) {
+  if (!SetModeOfOperation(OperationMode::kProfileVelocity)) {
+    RCLCPP_ERROR(logger_,
+                 "Failed to set operation mode to Profile Velocity for node %u",
+                 static_cast<unsigned>(node_id_));
+  }
+}
+
+MotorController::MotorController(std::shared_ptr<can_control::CanInterface> can,
+                                 uint8_t node_id,
+                                 const MotorParameters& params)
+    : can_(std::move(can)),
+      node_id_(node_id),
+      motor_params_(params),
       logger_(rclcpp::get_logger("MotorController")) {
   if (!SetModeOfOperation(OperationMode::kProfileVelocity)) {
     RCLCPP_ERROR(logger_,


### PR DESCRIPTION
## Summary
- add a new `MotorParameters` struct for motor configuration
- pass motor parameters from `MotionControllerNode` to `MotionController`
- propagate parameters to each `MotorController` instance

## Testing
- `cmake` configure: **fails** due to missing `ament_cmake`
- `ctest`: no tests were found

------
https://chatgpt.com/codex/tasks/task_b_6853b8274930832285f77ce83dfb842e