### PR TITLE
Remove unused motor parameters

### DIFF
--- a/config/motion_control_mecanum_params.yaml
+++ b/config/motion_control_mecanum_params.yaml
@@ -14,11 +14,8 @@
         position: "RR"  # Rear-Right
     
       motor_parameters:
-        max_speed: 3000  # rpm
         acceleration: 1000
         deceleration: 1000
-        gear_ratio: 10.0
-        encoder_resolution: 4096
         max_torque: 1000
         end_velocity: 0
         quick_stop_deceleration: 1000

--- a/include/motion-control-mecanum/motor_parameters.hpp
+++ b/include/motion-control-mecanum/motor_parameters.hpp
@@ -6,11 +6,8 @@
 namespace motion_control_mecanum {
 
 struct MotorParameters {
-  int32_t max_speed{0};
   int32_t acceleration{0};
   int32_t deceleration{0};
-  double gear_ratio{0.0};
-  int32_t encoder_resolution{0};
   int32_t max_torque{0};
   int32_t end_velocity{0};
   int32_t quick_stop_deceleration{0};

--- a/src/motion-control-mecanum/motion_controller_node.cpp
+++ b/src/motion-control-mecanum/motion_controller_node.cpp
@@ -19,16 +19,10 @@ MotionControllerNode::MotionControllerNode(const rclcpp::NodeOptions& options)
       this->declare_parameter<std::string>("can_device", "can0");
 
   MotorParameters motor_params;
-  motor_params.max_speed =
-      this->declare_parameter<int>("motor_parameters.max_speed", 3000);
   motor_params.acceleration =
       this->declare_parameter<int>("motor_parameters.acceleration", 1000);
   motor_params.deceleration =
       this->declare_parameter<int>("motor_parameters.deceleration", 1000);
-  motor_params.gear_ratio =
-      this->declare_parameter<double>("motor_parameters.gear_ratio", 10.0);
-  motor_params.encoder_resolution =
-      this->declare_parameter<int>("motor_parameters.encoder_resolution", 4096);
   motor_params.max_torque =
       this->declare_parameter<int>("motor_parameters.max_torque", 1000);
   motor_params.end_velocity =


### PR DESCRIPTION
## Summary
- clean up `motor_parameters` interface
- drop unused params from sample config

## Testing
- `cmake ..` *(fails: could not find `ament_cmake`)*

------
https://chatgpt.com/codex/tasks/task_b_6853bdad224c8322b7a072cab118b882