### PR TITLE
Add WheelParameters struct

### DIFF
--- a/include/motion-control-mecanum/motion_controller.hpp
+++ b/include/motion-control-mecanum/motion_controller.hpp
@@ -9,18 +9,18 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "motion-control-mecanum/motor_controller.hpp"
 #include "motion-control-mecanum/motor_parameters.hpp"
+#include "motion-control-mecanum/wheel_parameters.hpp"
 
 namespace motion_control_mecanum {
 
 class MotionController {
  public:
-  MotionController(double wheel_radius, double wheel_separation_x,
-                   double wheel_separation_y);
+  explicit MotionController(const WheelParameters& wheel_params);
 
   MotionController(const std::string& can_device,
                    const std::array<uint8_t, 4>& node_ids,
-                   const MotorParameters& motor_params, double wheel_radius,
-                   double wheel_separation_x, double wheel_separation_y);
+                   const MotorParameters& motor_params,
+                   const WheelParameters& wheel_params);
 
   std::array<double, 4> compute(const geometry_msgs::msg::Twist& cmd) const;
 
@@ -31,9 +31,7 @@ class MotionController {
   bool servoOff();
 
  private:
-  double wheel_radius_;
-  double wheel_separation_x_;
-  double wheel_separation_y_;
+  WheelParameters wheel_params_{};
 
   std::shared_ptr<can_control::SocketCanInterface> can_interface_;
   std::array<std::shared_ptr<MotorController>, 4> motor_controllers_{};

--- a/include/motion-control-mecanum/wheel_parameters.hpp
+++ b/include/motion-control-mecanum/wheel_parameters.hpp
@@ -1,0 +1,14 @@
+#ifndef MOTION_CONTROL_MECANUM__WHEEL_PARAMETERS_HPP_
+#define MOTION_CONTROL_MECANUM__WHEEL_PARAMETERS_HPP_
+
+namespace motion_control_mecanum {
+
+struct WheelParameters {
+  double radius{0.0};
+  double separation_x{0.0};
+  double separation_y{0.0};
+};
+
+}  // namespace motion_control_mecanum
+
+#endif  // MOTION_CONTROL_MECANUM__WHEEL_PARAMETERS_HPP_

--- a/src/motion-control-mecanum/motion_controller.cpp
+++ b/src/motion-control-mecanum/motion_controller.cpp
@@ -4,22 +4,14 @@
 
 namespace motion_control_mecanum {
 
-MotionController::MotionController(double wheel_radius,
-                                   double wheel_separation_x,
-                                   double wheel_separation_y)
-    : wheel_radius_(wheel_radius),
-      wheel_separation_x_(wheel_separation_x),
-      wheel_separation_y_(wheel_separation_y) {}
+MotionController::MotionController(const WheelParameters& wheel_params)
+    : wheel_params_(wheel_params) {}
 
 MotionController::MotionController(const std::string& can_device,
                                    const std::array<uint8_t, 4>& node_ids,
                                    const MotorParameters& motor_params,
-                                   double wheel_radius,
-                                   double wheel_separation_x,
-                                   double wheel_separation_y)
-    : wheel_radius_(wheel_radius),
-      wheel_separation_x_(wheel_separation_x),
-      wheel_separation_y_(wheel_separation_y) {
+                                   const WheelParameters& wheel_params)
+    : wheel_params_(wheel_params) {
   can_interface_ =
       std::make_shared<can_control::SocketCanInterface>(can_device);
   for (size_t i = 0; i < motor_controllers_.size(); ++i) {
@@ -30,18 +22,18 @@ MotionController::MotionController(const std::string& can_device,
 
 std::array<double, 4> MotionController::compute(
     const geometry_msgs::msg::Twist& cmd) const {
-  const double Lx = wheel_separation_x_ / 2.0;
-  const double Ly = wheel_separation_y_ / 2.0;
+  const double Lx = wheel_params_.separation_x / 2.0;
+  const double Ly = wheel_params_.separation_y / 2.0;
   const double k = Lx + Ly;
   const double vx = cmd.linear.x;
   const double vy = cmd.linear.y;
   const double wz = cmd.angular.z;
 
   std::array<double, 4> speeds{};
-  speeds[0] = (vx - vy - k * wz) / wheel_radius_;  // front left
-  speeds[1] = (vx + vy + k * wz) / wheel_radius_;  // front right
-  speeds[2] = (vx + vy - k * wz) / wheel_radius_;  // rear left
-  speeds[3] = (vx - vy + k * wz) / wheel_radius_;  // rear right
+  speeds[0] = (vx - vy - k * wz) / wheel_params_.radius;  // front left
+  speeds[1] = (vx + vy + k * wz) / wheel_params_.radius;  // front right
+  speeds[2] = (vx + vy - k * wz) / wheel_params_.radius;  // rear left
+  speeds[3] = (vx - vy + k * wz) / wheel_params_.radius;  // rear right
   return speeds;
 }
 

--- a/src/motion-control-mecanum/motion_controller_node.cpp
+++ b/src/motion-control-mecanum/motion_controller_node.cpp
@@ -2,6 +2,7 @@
 
 #include "std_srvs/srv/trigger.hpp"
 #include "motion-control-mecanum/motor_parameters.hpp"
+#include "motion-control-mecanum/wheel_parameters.hpp"
 
 namespace motion_control_mecanum {
 
@@ -36,8 +37,9 @@ MotionControllerNode::MotionControllerNode(const rclcpp::NodeOptions& options)
       this->declare_parameter<int>("motor_parameters.velocity_threshold", 0);
 
   std::array<uint8_t, 4> node_ids{1, 2, 3, 4};
+  WheelParameters wheel_params{radius, sep_x, sep_y};
   motion_controller_ = std::make_shared<MotionController>(
-      can_dev, node_ids, motor_params, radius, sep_x, sep_y);
+      can_dev, node_ids, motor_params, wheel_params);
 
   cmd_vel_sub_ = create_subscription<geometry_msgs::msg::Twist>(
       "cmd_vel", rclcpp::QoS(10),

--- a/test/test_motion_controller.cpp
+++ b/test/test_motion_controller.cpp
@@ -2,9 +2,11 @@
 
 #include "geometry_msgs/msg/twist.hpp"
 #include "motion-control-mecanum/motion_controller.hpp"
+#include "motion-control-mecanum/wheel_parameters.hpp"
 
 TEST(MotionControllerTest, StraightX) {
-  motion_control_mecanum::MotionController mc(0.1, 0.2, 0.2);
+  motion_control_mecanum::WheelParameters wp{0.1, 0.2, 0.2};
+  motion_control_mecanum::MotionController mc(wp);
   geometry_msgs::msg::Twist cmd;
   cmd.linear.x = 1.0;
   auto speeds = mc.compute(cmd);
@@ -14,7 +16,8 @@ TEST(MotionControllerTest, StraightX) {
 }
 
 TEST(MotionControllerTest, StraightY) {
-  motion_control_mecanum::MotionController mc(0.1, 0.2, 0.2);
+  motion_control_mecanum::WheelParameters wp{0.1, 0.2, 0.2};
+  motion_control_mecanum::MotionController mc(wp);
   geometry_msgs::msg::Twist cmd;
   cmd.linear.y = 1.0;
   auto speeds = mc.compute(cmd);


### PR DESCRIPTION
## Summary
- add `WheelParameters` struct to hold wheel configuration
- use the struct in `MotionController` constructors
- pass `WheelParameters` from `MotionControllerNode`
- adjust tests for the new constructor

## Testing
- `cmake -S . -B build` *(fails: could not find `ament_cmake`)*

------
https://chatgpt.com/codex/tasks/task_b_6853c2005eec832280079b175717c3fc