### PR TITLE
Move SocketCan creation to node

### DIFF
--- a/include/motion-control-mecanum/motion_controller.hpp
+++ b/include/motion-control-mecanum/motion_controller.hpp
@@ -17,7 +17,7 @@ class MotionController {
  public:
   explicit MotionController(const WheelParameters& wheel_params);
 
-  MotionController(const std::string& can_device,
+  MotionController(std::shared_ptr<can_control::SocketCanInterface> can_interface,
                    const std::array<uint8_t, 4>& node_ids,
                    const MotorParameters& motor_params,
                    const WheelParameters& wheel_params);

--- a/include/motion-control-mecanum/motion_controller_node.hpp
+++ b/include/motion-control-mecanum/motion_controller_node.hpp
@@ -6,6 +6,7 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "motion-control-mecanum/motion_controller.hpp"
 #include "motion-control-mecanum/motor_parameters.hpp"
+#include "can/socket_can_interface.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
@@ -30,6 +31,7 @@ class MotionControllerNode : public rclcpp::Node {
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr servo_on_service_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr servo_off_service_;
+  std::shared_ptr<can_control::SocketCanInterface> can_interface_;
   std::shared_ptr<MotionController> motion_controller_;
 };
 

--- a/src/motion-control-mecanum/motion_controller.cpp
+++ b/src/motion-control-mecanum/motion_controller.cpp
@@ -7,13 +7,11 @@ namespace motion_control_mecanum {
 MotionController::MotionController(const WheelParameters& wheel_params)
     : wheel_params_(wheel_params) {}
 
-MotionController::MotionController(const std::string& can_device,
-                                   const std::array<uint8_t, 4>& node_ids,
-                                   const MotorParameters& motor_params,
-                                   const WheelParameters& wheel_params)
-    : wheel_params_(wheel_params) {
-  can_interface_ =
-      std::make_shared<can_control::SocketCanInterface>(can_device);
+MotionController::MotionController(
+    std::shared_ptr<can_control::SocketCanInterface> can_interface,
+    const std::array<uint8_t, 4>& node_ids, const MotorParameters& motor_params,
+    const WheelParameters& wheel_params)
+    : wheel_params_(wheel_params), can_interface_(std::move(can_interface)) {
   for (size_t i = 0; i < motor_controllers_.size(); ++i) {
     motor_controllers_[i] = std::make_shared<MotorController>(
         can_interface_, node_ids[i], motor_params);

--- a/src/motion-control-mecanum/motion_controller_node.cpp
+++ b/src/motion-control-mecanum/motion_controller_node.cpp
@@ -38,8 +38,9 @@ MotionControllerNode::MotionControllerNode(const rclcpp::NodeOptions& options)
 
   std::array<uint8_t, 4> node_ids{1, 2, 3, 4};
   WheelParameters wheel_params{radius, sep_x, sep_y};
+  can_interface_ = std::make_shared<can_control::SocketCanInterface>(can_dev);
   motion_controller_ = std::make_shared<MotionController>(
-      can_dev, node_ids, motor_params, wheel_params);
+      can_interface_, node_ids, motor_params, wheel_params);
 
   cmd_vel_sub_ = create_subscription<geometry_msgs::msg::Twist>(
       "cmd_vel", rclcpp::QoS(10),


### PR DESCRIPTION
## Summary
- instantiate `SocketCanInterface` inside `MotionControllerNode`
- pass the created interface to `MotionController` via new constructor
- expose the CAN interface pointer in the node

## Testing
- `colcon build` *(fails: command not found)*
- `ament_cmake test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853c48490d88322b1c5837c80251941