### PR TITLE
Add Shutdown call before setting motor parameters

### DIFF
--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -33,6 +33,7 @@ MotorController::MotorController(std::shared_ptr<can_control::CanInterface> can,
 
 bool MotorController::ConfigureMotorParameters() {
   bool success = true;
+  success &= Shutdown();
   success &= SetModeOfOperation(OperationMode::kProfileVelocity);
   success &= SetTargetVelocity(0);
   success &=


### PR DESCRIPTION
## Summary
- ensure motors are shut down before configuring parameters

## Testing
- `cmake -S . -B build` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_6853fd7ecdac8322a0de6c7ade1093b6