### PR TITLE
Skip compute if controller not running

### DIFF
--- a/src/motion-control-mecanum/motion_controller_node.cpp
+++ b/src/motion-control-mecanum/motion_controller_node.cpp
@@ -90,7 +90,9 @@ void MotionControllerNode::cmdVelCallback(
       std::clamp(limited.angular.z, -control_params_.max_angular_velocity,
                  control_params_.max_angular_velocity);
 
-  (void)motion_controller_->compute(limited);
+  if (motion_controller_->getState() == MotionState::kRunning) {
+    (void)motion_controller_->compute(limited);
+  }
 }
 
 void MotionControllerNode::handleServoOn(


### PR DESCRIPTION
## Summary
- check MotionController state in MotionControllerNode::cmdVelCallback
- only compute when the controller is running

## Testing
- `colcon test --event-handlers console_direct+` *(fails: colcon not found)*
- `cmake .. && make -j$(nproc) && ctest --output-on-failure` *(fails: could not find ament_cmake)*


------
https://chatgpt.com/codex/tasks/task_b_6854034926d08322960b73c6aa6916f8