### PR TITLE
Implement motion_control_mecanum_launch.py

### DIFF
--- a/launch/motion_control_mecanum_launch.py
+++ b/launch/motion_control_mecanum_launch.py
@@ -1,0 +1,23 @@
+import os
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+
+def generate_launch_description() -> LaunchDescription:
+    pkg_share = get_package_share_directory('motion-control-mecanum-pkg')
+    params_file = os.path.join(
+        pkg_share,
+        'config',
+        'motion_control_mecanum_params.yaml',
+    )
+
+    motion_controller_node = Node(
+        package='motion-control-mecanum-pkg',
+        executable='motion_controller_node',
+        name='motion_controller_node',
+        output='screen',
+        parameters=[params_file],
+    )
+
+    return LaunchDescription([motion_controller_node])


### PR DESCRIPTION
## Summary
- implement missing launch file using motion_control_mecanum_params.yaml

## Testing
- `python3 -m py_compile launch/motion_control_mecanum_launch.py`
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854126e91f48322a2b5e3210544fb3a