### PR TITLE
Add info logs on motor parameter setters

### DIFF
--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -215,6 +215,9 @@ bool MotorController::SetVelocityThreshold(uint16_t threshold) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
+  RCLCPP_INFO(logger_, "SetVelocityThreshold(%u): %u",
+              static_cast<unsigned>(node_id_),
+              static_cast<unsigned>(threshold));
   return true;
 }
 
@@ -240,6 +243,9 @@ bool MotorController::SetVelocityWindow(uint16_t window) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
+  RCLCPP_INFO(logger_, "SetVelocityWindow(%u): %u",
+              static_cast<unsigned>(node_id_),
+              static_cast<unsigned>(window));
   return true;
 }
 
@@ -266,6 +272,9 @@ bool MotorController::SetQuickStopOptionCode(QuickStopOptionCode option) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
+  RCLCPP_INFO(logger_, "SetQuickStopOptionCode(%u): %d",
+              static_cast<unsigned>(node_id_),
+              static_cast<int>(option));
   return true;
 }
 
@@ -291,6 +300,9 @@ bool MotorController::SetQuickStopDeceleration(uint32_t deceleration) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
+  RCLCPP_INFO(logger_, "SetQuickStopDeceleration(%u): %u",
+              static_cast<unsigned>(node_id_),
+              static_cast<unsigned>(deceleration));
   return true;
 }
 
@@ -316,6 +328,9 @@ bool MotorController::SetProfileAcceleration(uint32_t acceleration) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
+  RCLCPP_INFO(logger_, "SetProfileAcceleration(%u): %u",
+              static_cast<unsigned>(node_id_),
+              static_cast<unsigned>(acceleration));
   return true;
 }
 
@@ -341,6 +356,9 @@ bool MotorController::SetProfileDeceleration(uint32_t deceleration) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
+  RCLCPP_INFO(logger_, "SetProfileDeceleration(%u): %u",
+              static_cast<unsigned>(node_id_),
+              static_cast<unsigned>(deceleration));
   return true;
 }
 
@@ -366,6 +384,9 @@ bool MotorController::SetEndVelocity(int32_t velocity) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
+  RCLCPP_INFO(logger_, "SetEndVelocity(%u): %d",
+              static_cast<unsigned>(node_id_),
+              velocity);
   return true;
 }
 
@@ -416,6 +437,9 @@ bool MotorController::SetMaxTorque(uint16_t max_torque) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
+  RCLCPP_INFO(logger_, "SetMaxTorque(%u): %u",
+              static_cast<unsigned>(node_id_),
+              static_cast<unsigned>(max_torque));
   return true;
 }
 


### PR DESCRIPTION
## Summary
- log success for velocity threshold, window, and quick stop settings
- log success for profile and torque configuration methods

## Testing
- `colcon test --parallel-workers 1 --event-handlers console_direct+ --return-code-on-test-failure` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685922f5f88c832297b705cdd9cc6480