### PR TITLE
Switch motor info logs to debug

### DIFF
--- a/src/motion-control-mecanum/motor_controller.cpp
+++ b/src/motion-control-mecanum/motor_controller.cpp
@@ -215,7 +215,7 @@ bool MotorController::SetVelocityThreshold(uint16_t threshold) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
-  RCLCPP_INFO(logger_, "SetVelocityThreshold(%u): %u",
+  RCLCPP_DEBUG(logger_, "SetVelocityThreshold(%u): %u",
               static_cast<unsigned>(node_id_),
               static_cast<unsigned>(threshold));
   return true;
@@ -243,7 +243,7 @@ bool MotorController::SetVelocityWindow(uint16_t window) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
-  RCLCPP_INFO(logger_, "SetVelocityWindow(%u): %u",
+  RCLCPP_DEBUG(logger_, "SetVelocityWindow(%u): %u",
               static_cast<unsigned>(node_id_),
               static_cast<unsigned>(window));
   return true;
@@ -272,7 +272,7 @@ bool MotorController::SetQuickStopOptionCode(QuickStopOptionCode option) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
-  RCLCPP_INFO(logger_, "SetQuickStopOptionCode(%u): %d",
+  RCLCPP_DEBUG(logger_, "SetQuickStopOptionCode(%u): %d",
               static_cast<unsigned>(node_id_),
               static_cast<int>(option));
   return true;
@@ -300,7 +300,7 @@ bool MotorController::SetQuickStopDeceleration(uint32_t deceleration) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
-  RCLCPP_INFO(logger_, "SetQuickStopDeceleration(%u): %u",
+  RCLCPP_DEBUG(logger_, "SetQuickStopDeceleration(%u): %u",
               static_cast<unsigned>(node_id_),
               static_cast<unsigned>(deceleration));
   return true;
@@ -328,7 +328,7 @@ bool MotorController::SetProfileAcceleration(uint32_t acceleration) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
-  RCLCPP_INFO(logger_, "SetProfileAcceleration(%u): %u",
+  RCLCPP_DEBUG(logger_, "SetProfileAcceleration(%u): %u",
               static_cast<unsigned>(node_id_),
               static_cast<unsigned>(acceleration));
   return true;
@@ -356,7 +356,7 @@ bool MotorController::SetProfileDeceleration(uint32_t deceleration) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
-  RCLCPP_INFO(logger_, "SetProfileDeceleration(%u): %u",
+  RCLCPP_DEBUG(logger_, "SetProfileDeceleration(%u): %u",
               static_cast<unsigned>(node_id_),
               static_cast<unsigned>(deceleration));
   return true;
@@ -384,7 +384,7 @@ bool MotorController::SetEndVelocity(int32_t velocity) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
-  RCLCPP_INFO(logger_, "SetEndVelocity(%u): %d",
+  RCLCPP_DEBUG(logger_, "SetEndVelocity(%u): %d",
               static_cast<unsigned>(node_id_),
               velocity);
   return true;
@@ -437,7 +437,7 @@ bool MotorController::SetMaxTorque(uint16_t max_torque) {
                  static_cast<unsigned>(node_id_));
     return false;
   }
-  RCLCPP_INFO(logger_, "SetMaxTorque(%u): %u",
+  RCLCPP_DEBUG(logger_, "SetMaxTorque(%u): %u",
               static_cast<unsigned>(node_id_),
               static_cast<unsigned>(max_torque));
   return true;


### PR DESCRIPTION
## Summary
- change `RCLCPP_INFO` to `RCLCPP_DEBUG` for several configuration calls in `MotorController`

## Testing
- `colcon test --packages-select motion-control-mecanum` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68592af04e9c832293ad5c4ba174d04b