### PR TITLE
Add gear ratio parameter

### DIFF
--- a/config/motion_control_mecanum_params.yaml
+++ b/config/motion_control_mecanum_params.yaml
@@ -22,6 +22,7 @@
       wheel_radius: 0.075  # m
       wheel_distance_x: 0.3  # m
       wheel_distance_y: 0.25  # m
+      gear_ratio: 100
     
     control_parameters:
       control_frequency: 50.0  # Hz

--- a/include/motion-control-mecanum/wheel_parameters.hpp
+++ b/include/motion-control-mecanum/wheel_parameters.hpp
@@ -7,6 +7,7 @@ struct WheelParameters {
   double radius{0.0};
   double separation_x{0.0};
   double separation_y{0.0};
+  double gear_ratio{1.0};
 };
 
 }  // namespace motion_control_mecanum

--- a/src/motion-control-mecanum/motion_controller.cpp
+++ b/src/motion-control-mecanum/motion_controller.cpp
@@ -33,10 +33,14 @@ bool MotionController::compute(const geometry_msgs::msg::Twist& cmd) {
   RCLCPP_DEBUG(logger_, "compute: vx=%.3f vy=%.3f wz=%.3f", vx, vy, wz);
 
   std::array<double, 4> speeds{};
-  speeds[0] = (vx - vy - k * wz) / wheel_params_.radius;  // front left
-  speeds[1] = (vx + vy + k * wz) / wheel_params_.radius;  // front right
-  speeds[2] = (vx + vy - k * wz) / wheel_params_.radius;  // rear left
-  speeds[3] = (vx - vy + k * wz) / wheel_params_.radius;  // rear right
+  speeds[0] =
+      (vx - vy - k * wz) / wheel_params_.radius * wheel_params_.gear_ratio;  // front left
+  speeds[1] =
+      (vx + vy + k * wz) / wheel_params_.radius * wheel_params_.gear_ratio;  // front right
+  speeds[2] =
+      (vx + vy - k * wz) / wheel_params_.radius * wheel_params_.gear_ratio;  // rear left
+  speeds[3] =
+      (vx - vy + k * wz) / wheel_params_.radius * wheel_params_.gear_ratio;  // rear right
 
   RCLCPP_DEBUG(logger_, "target speeds: [%.3f, %.3f, %.3f, %.3f]", speeds[0], speeds[1], speeds[2], speeds[3]);
 
@@ -142,7 +146,7 @@ bool MotionController::computeOdometry(double dt,
 
   std::array<double, 4> w{};
   for (size_t i = 0; i < w.size(); ++i) {
-    w[i] = static_cast<double>(velocities[i]);
+    w[i] = static_cast<double>(velocities[i]) / wheel_params_.gear_ratio;
   }
 
   const double Lx = wheel_params_.separation_x / 2.0;

--- a/src/motion-control-mecanum/motion_controller_node.cpp
+++ b/src/motion-control-mecanum/motion_controller_node.cpp
@@ -29,6 +29,8 @@ void MotionControllerNode::initialize(
       declare_parameter<double>("wheel_parameters.wheel_separation_x", 0.30);
   wheel_params.separation_y =
       declare_parameter<double>("wheel_parameters.wheel_separation_y", 0.25);
+  wheel_params.gear_ratio =
+      declare_parameter<double>("wheel_parameters.gear_ratio", 1.0);
 
   std::string can_dev = declare_parameter<std::string>("can_device", "can0");
 

--- a/test/test_motion_controller.cpp
+++ b/test/test_motion_controller.cpp
@@ -5,7 +5,7 @@
 #include "motion-control-mecanum/wheel_parameters.hpp"
 
 TEST(MotionControllerTest, StraightX) {
-  motion_control_mecanum::WheelParameters wp{0.1, 0.2, 0.2};
+  motion_control_mecanum::WheelParameters wp{0.1, 0.2, 0.2, 1.0};
   motion_control_mecanum::MotionController mc(wp);
   geometry_msgs::msg::Twist cmd;
   cmd.linear.x = 1.0;
@@ -13,7 +13,7 @@ TEST(MotionControllerTest, StraightX) {
 }
 
 TEST(MotionControllerTest, StraightY) {
-  motion_control_mecanum::WheelParameters wp{0.1, 0.2, 0.2};
+  motion_control_mecanum::WheelParameters wp{0.1, 0.2, 0.2, 1.0};
   motion_control_mecanum::MotionController mc(wp);
   geometry_msgs::msg::Twist cmd;
   cmd.linear.y = 1.0;


### PR DESCRIPTION
## Summary
- add `gear_ratio` to the default configuration
- store gear ratio in `WheelParameters`
- read the new parameter in `MotionControllerNode`
- apply gear ratio when setting motor velocities and when computing odometry
- update tests for new struct layout

## Testing
- `cmake ..` *(fails: ament_cmake not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cb4f3b73083228e105278f53c4ff2