### PR TITLE
Add odom topic parameter

### DIFF
--- a/config/motion_control_mecanum_params.yaml
+++ b/config/motion_control_mecanum_params.yaml
@@ -31,6 +31,7 @@
 
     odom_frame_id: "odom"
     base_frame_id: "base_link"
+    odom_topic_name: "odom"
     
     safety_parameters:
       timeout_ms: 500

--- a/include/motion-control-mecanum/motion_controller_node.hpp
+++ b/include/motion-control-mecanum/motion_controller_node.hpp
@@ -53,6 +53,7 @@ class MotionControllerNode : public rclcpp::Node {
 
   std::string odom_frame_id_{};
   std::string base_frame_id_{};
+  std::string odom_topic_name_{};
 
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr motor_state_pub_;
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;

--- a/src/motion-control-mecanum/motion_controller_node.cpp
+++ b/src/motion-control-mecanum/motion_controller_node.cpp
@@ -23,6 +23,7 @@ void MotionControllerNode::initialize(
   declare_parameter("control_parameters.max_angular_velocity", 1.5);
   declare_parameter("odom_frame_id", "odom");
   declare_parameter("base_frame_id", "base_link");
+  declare_parameter("odom_topic_name", "odom");
 
   WheelParameters wheel_params;
   wheel_params.radius =
@@ -77,6 +78,7 @@ void MotionControllerNode::initialize(
       get_parameter("control_parameters.max_angular_velocity").as_double();
   odom_frame_id_ = get_parameter("odom_frame_id").as_string();
   base_frame_id_ = get_parameter("base_frame_id").as_string();
+  odom_topic_name_ = get_parameter("odom_topic_name").as_string();
 
   cmd_vel_sub_ = create_subscription<geometry_msgs::msg::Twist>(
       "cmd_vel", rclcpp::QoS(10),
@@ -93,7 +95,7 @@ void MotionControllerNode::initialize(
   motor_state_pub_ =
       create_publisher<sensor_msgs::msg::JointState>("motor_states", 10);
   odom_pub_ =
-      create_publisher<nav_msgs::msg::Odometry>("odom", 10);
+      create_publisher<nav_msgs::msg::Odometry>(odom_topic_name_, 10);
   last_odom_time_ = now();
 
   publish_timer_ = create_wall_timer(


### PR DESCRIPTION
## Summary
- allow the odometry publisher topic to be configured via a new `odom_topic_name` parameter
- document the default topic in the params file

## Testing
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d23d5c59c8322a5ddf47bea707e87