### PR TITLE
Add unit tests for MotorController profile velocity and statusword

### DIFF
--- a/test/test_motor_controller_can.cpp
+++ b/test/test_motor_controller_can.cpp
@@ -52,3 +52,69 @@ TEST(MotorControllerCAN, SetModeOfOperation) {
   EXPECT_EQ(f.arbitration_id, motor_controller::kSdoRequestBaseId + 1);
   EXPECT_EQ(f.dlc, motor_controller::kSdoDlc);
 }
+
+TEST(MotorControllerCAN, SetProfileVelocity) {
+  auto mock = std::make_shared<MockCanInterface>();
+
+  motion_control_mecanum::MotorParameters params{};
+  motion_control_mecanum::MotorController mc(mock, 1, params);
+  mock->sent_frames.clear();
+  mock->recv_frames.clear();
+
+  CanFrame resp;
+  resp.arbitration_id = motor_controller::kSdoResponseBaseId + 1;
+  resp.dlc = 8;
+  resp.data = std::vector<uint8_t>{
+      motor_controller::kSdoExpectedResponseDownload, 0, 0, 0, 0, 0, 0, 0};
+  mock->recv_frames.push_back(resp);
+
+  int32_t velocity = 1234;
+  EXPECT_TRUE(mc.SetProfileVelocity(velocity));
+  ASSERT_EQ(mock->sent_frames.size(), 1u);
+  const auto& f = mock->sent_frames[0];
+  EXPECT_EQ(f.arbitration_id, motor_controller::kSdoRequestBaseId + 1);
+  EXPECT_EQ(f.dlc, motor_controller::kSdoDlc);
+  EXPECT_EQ(f.data[0], motor_controller::kSdoDownload4byteCmd);
+  EXPECT_EQ(f.data[1], 0x81);
+  EXPECT_EQ(f.data[2], 0x60);
+  EXPECT_EQ(f.data[3], 0x00);
+  EXPECT_EQ(f.data[4], static_cast<uint8_t>(velocity & 0xFF));
+  EXPECT_EQ(f.data[5], static_cast<uint8_t>((velocity >> 8) & 0xFF));
+  EXPECT_EQ(f.data[6], static_cast<uint8_t>((velocity >> 16) & 0xFF));
+  EXPECT_EQ(f.data[7], static_cast<uint8_t>((velocity >> 24) & 0xFF));
+}
+
+TEST(MotorControllerCAN, ReadStatusword) {
+  auto mock = std::make_shared<MockCanInterface>();
+
+  motion_control_mecanum::MotorParameters params{};
+  motion_control_mecanum::MotorController mc(mock, 1, params);
+  mock->sent_frames.clear();
+  mock->recv_frames.clear();
+
+  uint16_t status = 0x1234;
+  CanFrame resp;
+  resp.arbitration_id = motor_controller::kSdoResponseBaseId + 1;
+  resp.dlc = 8;
+  resp.data = std::vector<uint8_t>{
+      motor_controller::kSdoExpectedResponseUpload,
+      0, 0, 0,
+      static_cast<uint8_t>(status & 0xFF),
+      static_cast<uint8_t>((status >> 8) & 0xFF),
+      0,
+      0};
+  mock->recv_frames.push_back(resp);
+
+  uint16_t out_status = 0;
+  EXPECT_TRUE(mc.readStatusword(&out_status));
+  EXPECT_EQ(out_status, status);
+
+  ASSERT_EQ(mock->sent_frames.size(), 1u);
+  const auto& f = mock->sent_frames[0];
+  EXPECT_EQ(f.arbitration_id, motor_controller::kSdoRequestBaseId + 1);
+  EXPECT_EQ(f.dlc, motor_controller::kSdoDlc);
+  EXPECT_EQ(f.data[0], 0x40);
+  EXPECT_EQ(f.data[1], 0x41);
+  EXPECT_EQ(f.data[2], 0x60);
+  EXPECT_EQ(f.data[3], 0x00);
+}


### PR DESCRIPTION
## Summary
- expand test suite for MotorController
- add tests covering `SetProfileVelocity` and `readStatusword`

## Testing
- `cmake ..` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_685f4b9bd8fc8322ba4484e7cbdf368b