### PR TITLE
Fix GitHub action to run on develop PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ROS 2 CI (colcon + coverage)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
## Summary
- update workflow trigger branches to include `develop`

## Testing
- `pytest -q`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_685fbdf329148322bd931768939866c2