### PR TITLE
Make CI workflow reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     branches: [main, develop]
   workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      repo-path:
+        type: string
+        required: false
+        default: motion-control-mecanum
+      ros_distro:
+        type: string
+        required: false
+        default: humble
 
 jobs:
   build-and-test:
@@ -11,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        ros_distro: [humble]      # iron / jazzy を追加する場合はここに列挙
+        ros_distro: [${{ inputs.ros_distro }}]      # iron / jazzy を追加する場合はここに列挙
 
     container:
       image: ros:${{ matrix.ros_distro }}-ros-base-jammy  # Ubuntu22.04 + ROS2
@@ -24,7 +34,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        path: ros2_ws/src/motion-control-mecanum
+        path: ros2_ws/src/${{ inputs['repo-path'] }}
 
     # 2. APT キャッシュ ------------------------------------------------------
     - name: Cache APT packages
@@ -128,7 +138,7 @@ jobs:
       working-directory: ros2_ws
       run: |
         mkdir -p complexity_html
-        lizard --html -o complexity_html/index.html src/motion-control-mecanum src/can include/motion-control-mecanum include/can
+        lizard --html -o complexity_html/index.html src/${{ inputs['repo-path'] }}/src src/${{ inputs['repo-path'] }}/include
 
     # 13. 生成したレポートをまとめてアーティファクトとして保存 -------------
     - name: Upload CI reports artifact

--- a/README.md
+++ b/README.md
@@ -18,3 +18,20 @@ This package provides a simple example of a mecanum wheel motion controller for 
 * Ability to read the torque actual value (`0x6077`).
 * Ability to read the velocity actual value (`0x606C`).
 * Servo ON/OFF services to control motor power state.
+
+### Reusable CI Workflow
+
+This repository exposes a reusable GitHub Actions workflow at
+`.github/workflows/ci.yml`. Other ROS 2 packages can invoke it using
+`workflow_call`:
+
+```yaml
+name: CI
+on:
+  pull_request:
+jobs:
+  build-and-test:
+    uses: <owner>/motion-control-mecanum/.github/workflows/ci.yml@main
+    with:
+      repo-path: <your-package-name>
+```


### PR DESCRIPTION
## Summary
- allow `ci.yml` to be called from other repositories
- generalize checkout and complexity analysis paths
- document how to invoke the workflow

## Testing
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685fd45f565c8322927987fb951ca037