### PR TITLE
Add tf broadcaster from odom to base_link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(geometry_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_msgs REQUIRED)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
@@ -30,6 +32,7 @@ ament_target_dependencies(motion_control_mecanum
   std_srvs
   sensor_msgs
   nav_msgs
+  tf2_ros
 )
 
 add_executable(motion_controller_node
@@ -42,6 +45,7 @@ ament_target_dependencies(motion_controller_node
   std_srvs
   sensor_msgs
   nav_msgs
+  tf2_ros
 )
 
 install(TARGETS motion_control_mecanum motion_controller_node
@@ -70,7 +74,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_motion_controller_node test/test_motion_controller_node.cpp)
   if(TARGET test_motion_controller_node)
     target_link_libraries(test_motion_controller_node motion_control_mecanum)
-    ament_target_dependencies(test_motion_controller_node rclcpp std_srvs sensor_msgs)
+    ament_target_dependencies(test_motion_controller_node rclcpp std_srvs sensor_msgs tf2_ros tf2_msgs)
   endif()
 endif()
 

--- a/include/motion-control-mecanum/motion_controller_node.hpp
+++ b/include/motion-control-mecanum/motion_controller_node.hpp
@@ -13,6 +13,8 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/trigger.hpp"
+#include "tf2_ros/transform_broadcaster.h"
+#include "geometry_msgs/msg/transform_stamped.hpp"
 
 namespace motion_control_mecanum {
 
@@ -59,6 +61,7 @@ class MotionControllerNode : public rclcpp::Node {
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
   rclcpp::Time last_odom_time_;
   rclcpp::TimerBase::SharedPtr publish_timer_;
+  std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 };
 
 }  // namespace motion_control_mecanum

--- a/package.xml
+++ b/package.xml
@@ -14,14 +14,18 @@
   <build_depend>std_srvs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>tf2_ros</test_depend>
+  <test_depend>tf2_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/motion-control-mecanum/motion_controller_node.cpp
+++ b/src/motion-control-mecanum/motion_controller_node.cpp
@@ -183,22 +183,33 @@ void MotionControllerNode::publishMotorState() {
   nav_msgs::msg::Odometry odom;
   double dt = (current_time - last_odom_time_).seconds();
   last_odom_time_ = current_time;
-  if (motion_controller_->computeOdometry(dt, &odom)) {
+  bool odom_valid = motion_controller_->computeOdometry(dt, &odom);
+  if (odom_valid) {
     odom.header.stamp = current_time;
     odom.header.frame_id = odom_frame_id_;
     odom.child_frame_id = base_frame_id_;
     odom_pub_->publish(odom);
+  }
 
-    geometry_msgs::msg::TransformStamped tf_msg;
-    tf_msg.header.stamp = current_time;
-    tf_msg.header.frame_id = odom_frame_id_;
-    tf_msg.child_frame_id = base_frame_id_;
+  geometry_msgs::msg::TransformStamped tf_msg;
+  tf_msg.header.stamp = current_time;
+  tf_msg.header.frame_id = odom_frame_id_;
+  tf_msg.child_frame_id = base_frame_id_;
+  if (odom_valid) {
     tf_msg.transform.translation.x = odom.pose.pose.position.x;
     tf_msg.transform.translation.y = odom.pose.pose.position.y;
     tf_msg.transform.translation.z = odom.pose.pose.position.z;
     tf_msg.transform.rotation = odom.pose.pose.orientation;
-    tf_broadcaster_->sendTransform(tf_msg);
+  } else {
+    tf_msg.transform.translation.x = 0.0;
+    tf_msg.transform.translation.y = 0.0;
+    tf_msg.transform.translation.z = 0.0;
+    tf_msg.transform.rotation.x = 0.0;
+    tf_msg.transform.rotation.y = 0.0;
+    tf_msg.transform.rotation.z = 0.0;
+    tf_msg.transform.rotation.w = 1.0;
   }
+  tf_broadcaster_->sendTransform(tf_msg);
 }
 
 }  // namespace motion_control_mecanum


### PR DESCRIPTION
## Summary
- broadcast a TF transform from `odom` to `base_link`
- expose broadcaster in motion controller node API
- update tests to check for TF messages
- depend on tf2_ros and tf2_msgs

## Testing
- `colcon test --packages-select motion-control-mecanum-pkg --event-handlers console_cohesion+ --return-code-on-test-failure` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6864ccc1147c832281dd743f6f5427cc