### PR TITLE
Fix odometry to right‑handed coordinates

### DIFF
--- a/src/motion-control-mecanum/motion_controller.cpp
+++ b/src/motion-control-mecanum/motion_controller.cpp
@@ -180,9 +180,10 @@ bool MotionController::computeOdometry(double dt,
 
   const double vx = wheel_params_.radius *
                     (w[0] + w[1] + w[2] + w[3]) / 4.0;
-  const double vy = wheel_params_.radius *
+  // Convert from left-handed to right-handed coordinates
+  const double vy = -wheel_params_.radius *
                     (-w[0] + w[1] + w[2] - w[3]) / 4.0;
-  const double wz = wheel_params_.radius *
+  const double wz = -wheel_params_.radius *
                     (-w[0] + w[1] - w[2] + w[3]) / (4.0 * k);
 
   pose_x_ += (vx * std::cos(pose_yaw_) - vy * std::sin(pose_yaw_)) * dt;

--- a/test/test_motion_controller.cpp
+++ b/test/test_motion_controller.cpp
@@ -121,3 +121,20 @@ TEST(MotionControllerTest, ComputeOdometry) {
   EXPECT_NEAR(odom.twist.twist.linear.y, 0.0, 1e-6);
   EXPECT_NEAR(odom.twist.twist.angular.z, 0.0, 1e-6);
 }
+
+TEST(MotionControllerTest, ComputeOdometryRotationRightHand) {
+  auto mock_can = std::make_shared<MockSocketCanInterface>();
+  motion_control_mecanum::MotorParameters mp{};
+  std::array<uint8_t, 4> node_ids{{1, 2, 3, 4}};
+  motion_control_mecanum::WheelParameters wp{0.1, 0.2, 0.2, 1.0};
+  motion_control_mecanum::MotionController mc(mock_can, node_ids, mp, wp);
+
+  mock_can->recv_frames.push_back(makeVelocityResp(1, 10));
+  mock_can->recv_frames.push_back(makeVelocityResp(2, 10));
+  mock_can->recv_frames.push_back(makeVelocityResp(3, 10));
+  mock_can->recv_frames.push_back(makeVelocityResp(4, 10));
+
+  nav_msgs::msg::Odometry odom;
+  ASSERT_TRUE(mc.computeOdometry(1.0, &odom));
+  EXPECT_LT(odom.pose.pose.orientation.z, 0.0);
+}


### PR DESCRIPTION
## Summary
- adjust odometry computation to convert from left‑handed to right‑handed coordinates
- add a unit test that verifies rotation direction

## Testing
- `cmake ..` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_68665aa0f7f48322922d8b3fafdd0591