### PR TITLE
Fix odometry handedness

### DIFF
--- a/src/motion-control-mecanum/motion_controller.cpp
+++ b/src/motion-control-mecanum/motion_controller.cpp
@@ -180,10 +180,10 @@ bool MotionController::computeOdometry(double dt,
 
   const double vx = wheel_params_.radius *
                     (w[0] + w[1] + w[2] + w[3]) / 4.0;
-  // Convert from left-handed to right-handed coordinates
-  const double vy = -wheel_params_.radius *
+  // Right-handed coordinate system
+  const double vy = wheel_params_.radius *
                     (-w[0] + w[1] + w[2] - w[3]) / 4.0;
-  const double wz = -wheel_params_.radius *
+  const double wz = wheel_params_.radius *
                     (-w[0] + w[1] - w[2] + w[3]) / (4.0 * k);
 
   pose_x_ += (vx * std::cos(pose_yaw_) - vy * std::sin(pose_yaw_)) * dt;

--- a/test/test_motion_controller.cpp
+++ b/test/test_motion_controller.cpp
@@ -136,5 +136,5 @@ TEST(MotionControllerTest, ComputeOdometryRotationRightHand) {
 
   nav_msgs::msg::Odometry odom;
   ASSERT_TRUE(mc.computeOdometry(1.0, &odom));
-  EXPECT_LT(odom.pose.pose.orientation.z, 0.0);
+  EXPECT_GT(odom.pose.pose.orientation.z, 0.0);
 }


### PR DESCRIPTION
## Summary
- correct odometry computation to use right-handed coordinates
- adjust unit test for new odometry sign

## Testing
- `colcon test --packages-select motion-control-mecanum-pkg --event-handlers console_direct+ --return-code-on-test-failure` *(fails: command not found)*
- `cmake .. && make` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_686780e6ebc48322aa1fb52c61f61785